### PR TITLE
Potential fix for code scanning alert no. 47: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -1,4 +1,6 @@
 name: NodeJS with Grunt
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Rumi1013/midnight-magnolia-website/security/code-scanning/47](https://github.com/Rumi1013/midnight-magnolia-website/security/code-scanning/47)

The correct way to fix this is to explicitly declare the necessary permissions for the job or workflow. In this case, the workflow is only checking out code and running a build—there is no requirement for write access to the repository contents or any other GitHub resource.  
To adhere to the principle of least privilege:

- Add a `permissions:` key, either at the workflow root (to apply globally) or at the job level. Here, adding it to the workflow root at line 2 is preferred for clarity and coverage.
- Set the minimum permission, which is typically `contents: read` for workflows that do not need to write to the repository or GitHub resources.

No new methods, imports, or complex modifications are needed—just insert the `permissions:` block in the YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
